### PR TITLE
fix project paths in build-extras.gradle

### DIFF
--- a/AndroidLibrary/GoogleExtras/play_apk_expansion/downloader_library/build-extras.gradle
+++ b/AndroidLibrary/GoogleExtras/play_apk_expansion/downloader_library/build-extras.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    debugCompile project(path: ':org.apache.cordova.xapkreader:library',configuration: "debug")
-    releaseCompile project(path: ':org.apache.cordova.xapkreader:library',configuration: "release")
+    debugCompile project(path: ':com.intel.xapkreader:library',configuration: "debug")
+    releaseCompile project(path: ':com.intel.xapkreader:library',configuration: "release")
  }


### PR DESCRIPTION
After making this change, I was able to build a project that includes this plugin using a version of cordova-android that has [PR #182](https://github.com/apache/cordova-android/pull/182) merged.
