### PR TITLE
bugfix: Google’s library cannot load a patch file if the version number is different from the main

### DIFF
--- a/AndroidLibrary/GoogleExtras/play_apk_expansion/downloader_library/AndroidManifest.xml
+++ b/AndroidLibrary/GoogleExtras/play_apk_expansion/downloader_library/AndroidManifest.xml
@@ -4,6 +4,6 @@
     android:versionCode="2"
     android:versionName="1.1" >
 
-    <uses-sdk android:minSdkVersion="4" android:targetSdkVersion="15"/>
-    
+    <uses-sdk android:targetSdkVersion="15"/>
+
 </manifest>

--- a/AndroidLibrary/GoogleExtras/play_apk_expansion/zip_file/src/com/android/vending/expansion/zipfile/APKExpansionSupport.java
+++ b/AndroidLibrary/GoogleExtras/play_apk_expansion/zip_file/src/com/android/vending/expansion/zipfile/APKExpansionSupport.java
@@ -47,7 +47,7 @@ public class APKExpansionSupport {
 					}
 				}
 				if ( patchVersion > 0 ) {
-					String strPatchPath = expPath + File.separator + "patch." + mainVersion + "." + packageName + ".obb";
+					String strPatchPath = expPath + File.separator + "patch." + patchVersion + "." + packageName + ".obb";
 					File main = new File(strPatchPath);
 					if ( main.isFile() ) {
 						ret.add(strPatchPath);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.intel.xapkreader",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Access files into APK Expansion Files",
   "cordova": {
     "id": "com.intel.xapkreader",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/01org/APKexpansion.git"
+    "url": "git+https://github.com/cognifit/APKexpansion.git"
   },
   "keywords": [
     "cordova",
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/01org/APKexpansion/issues"
+    "url": "https://github.com/cognifit/APKexpansion/issues"
   },
-  "homepage": "https://github.com/01org/APKexpansion#readme"
+  "homepage": "https://github.com/cognifit/APKexpansion#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -59,6 +59,7 @@
             <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
             <!-- Required to read and write the expansion files on shared storage -->
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
             <!-- Required to access Google Play Licensing -->
             <uses-permission android:name="com.android.vending.CHECK_LICENSE" />
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -64,7 +64,7 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="application">
-            <activity android:name="org.apache.cordova.xapkreader.XAPKDownloaderActivity" android:label="@string/app_name" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale">
+            <activity android:name="org.apache.cordova.xapkreader.XAPKDownloaderActivity" android:label="@string/app_name" android:configChanges="keyboardHidden|keyboard|locale">
             </activity>
             <service android:name=".XAPKDownloaderService" />
             <receiver android:name=".XAPKAlarmReceiver" />

--- a/src/android/XAPKReader.java
+++ b/src/android/XAPKReader.java
@@ -83,7 +83,7 @@ public class XAPKReader extends CordovaPlugin {
 
         if (action.equals("get")) {
             final String filename = args.getString(0);
-            final Context ctx = cordova.getActivity().getApplicationContext();     
+            final Context ctx = cordova.getActivity().getApplicationContext();
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
                     try {
@@ -101,6 +101,32 @@ public class XAPKReader extends CordovaPlugin {
                     }
                 }
             });
+            return true;
+        }
+
+        if (action.equals("checkPermissions")) {
+
+            XAPKReader.verifyStoragePermissions(cordova.getActivity());
+
+            // final String filename = args.getString(0);
+            // final Context ctx = cordova.getActivity().getApplicationContext();
+            // cordova.getThreadPool().execute(new Runnable() {
+            //     public void run() {
+            //         try {
+            //             Context context = cordova.getActivity().getApplicationContext();
+            //             Intent intent = new Intent(context, XAPKDownloaderActivity.class);
+            //             intent.putExtras(bundle);
+            //             cordova.getActivity().startActivity(intent);
+            //             // Read file
+            //             PluginResult result = XAPKReader.readFile(ctx, filename, mainVersion, patchVersion, PluginResult.MESSAGE_TYPE_ARRAYBUFFER);
+            //             callbackContext.sendPluginResult(result);
+            //         }
+            //         catch(Exception e) {
+            //             e.printStackTrace();
+            //             callbackContext.error(e.getLocalizedMessage());
+            //         }
+            //     }
+            // });
             return true;
         }
         return false;
@@ -166,6 +192,34 @@ public class XAPKReader extends CordovaPlugin {
         }
 
         return result;
+    }
+
+    // Storage Permissions
+    private static final int REQUEST_EXTERNAL_STORAGE = 1;
+    private static String[] PERMISSIONS_STORAGE = {
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE
+    };
+
+    /**
+     * Checks if the app has permission to write to device storage
+     *
+     * If the app does not has permission then the user will be prompted to grant permissions
+     *
+     * @param activity
+     */
+    private static void verifyStoragePermissions(Activity activity) {
+        // Check if we have write permission
+        int permission = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+        if (permission != PackageManager.PERMISSION_GRANTED) {
+            // We don't have permission so prompt the user
+            ActivityCompat.requestPermissions(
+                    activity,
+                    PERMISSIONS_STORAGE,
+                    REQUEST_EXTERNAL_STORAGE
+            );
+        }
     }
 
 }

--- a/src/android/XAPKReader.java
+++ b/src/android/XAPKReader.java
@@ -1,9 +1,13 @@
 package org.apache.cordova.xapkreader;
 
+import android.Manifest;
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.AssetFileDescriptor;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
 import android.util.Base64;
 import android.util.Log;
 

--- a/www/xapkreader.js
+++ b/www/xapkreader.js
@@ -5,6 +5,13 @@ var inProgress = 0;
 module.exports = {
 
     /**
+     * Check for file permissions on new SDK
+     **/
+    checkFilePermissions: function(successCallback, errorCallback) {
+        cordova.exec(successCallback, errorCallback, "XAPKReader", "checkPermissions");
+    },
+
+    /**
      * Get a file immediately in expansion file
      *
      * @param filename              The file name
@@ -42,13 +49,13 @@ module.exports = {
 
     /**
      * Adds queue to retrieve at most 10 get’s simultaneously.
-     **/               
+     **/
     processQueue:  function() {
         while (inProgress < 10) {
             var e = getQueue.pop();
             if (!e) break;
             inProgress = inProgress + 1;
-            this.getImmediate(e.filename, e.successCallback, e.errorCallBack, e.fileType);      
+            this.getImmediate(e.filename, e.successCallback, e.errorCallBack, e.fileType);
         }
     },
 
@@ -64,28 +71,28 @@ module.exports = {
      **/
     get: function(filename, successCallback, errorCallBack, fileType) {
         var self = this;
-        
+
         getQueue.push({filename: filename,
         successCallback: function (x) {
-            successCallback(x); 
+            successCallback(x);
             self.getFinished();
         },
         errorCallBack: function(x) {
-            errorCallBack(x); 
+            errorCallBack(x);
             self.getFinished();
         },
         fileType: fileType});
-        
+
         this.processQueue();
     },
-    
+
     /**
      * Progress queue termination of 10 gets
      **/
     getFinished: function() {
         console.log('getfinished');
         inProgress = inProgress - 1;
-        this.processQueue();  
+        this.processQueue();
     },
 
     /**

--- a/www/xapkreader.js
+++ b/www/xapkreader.js
@@ -1,3 +1,4 @@
+cordova.define("com.intel.xapkreader.XAPKReader", function(require, exports, module) {
 var exec = require("cordova/exec");
 var getQueue = [];
 var inProgress = 0;
@@ -140,3 +141,5 @@ module.exports = {
     }
 
 };
+
+});

--- a/www/xapkreader.js
+++ b/www/xapkreader.js
@@ -1,4 +1,3 @@
-cordova.define("com.intel.xapkreader.XAPKReader", function(require, exports, module) {
 var exec = require("cordova/exec");
 var getQueue = [];
 var inProgress = 0;
@@ -142,4 +141,3 @@ module.exports = {
 
 };
 
-});


### PR DESCRIPTION
As far as I can see this is an error, the main and patch files can have different version numbers.
The error is easy to see in Google's code: the path for the patch file uses the mainVersion value.

Google's version of this file still contains this bug. Either that or I'm not understanding patch file versioning correctly.

regards,

Pedro
